### PR TITLE
Fix: update main workflow that use argument to send token instead of env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,9 +50,8 @@ jobs:
         run: make test
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   tests_mac:


### PR DESCRIPTION
### Summary :memo:
Fix the CI workflow issue that fails to send code coverage result to codecov

### Details
_Describe more what you did on changes._
1. use `with: token` instead of `env: CODECOV_TOKEN`
